### PR TITLE
fixed typo in string 'peer_list_fragment_empty'

### DIFF
--- a/wallet/res/values-de/strings.xml
+++ b/wallet/res/values-de/strings.xml
@@ -166,7 +166,7 @@
 
 	<string name="peer_monitor_activity_title">Peer Monitor</string>
 
-	<string name="peer_list_fragment_empty">Keine Peers verbinden</string>
+	<string name="peer_list_fragment_empty">Keine Peers verbunden</string>
 
 	<string name="block_explorer_activity_title">Block Explorer</string>
 


### PR DESCRIPTION
just a little typo in string peer_list_fragment_empty (german)
